### PR TITLE
Add configurable closed offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Garage Door Card
+
+This repository contains a Home Assistant Lovelace card that renders a neon-themed garage door with slats.
+
+## Configuration
+
+Add the card in your Lovelace configuration:
+
+```yaml
+- type: custom:garagedoor-card
+  entity: cover.garage_door
+```
+
+### Adjustable values
+
+Several values near the top of `garagedoor-card.js` can be modified to fine-tune the layout. Among them is the new `#closedOffset` field which controls the extra translation applied to the slats when the door is fully closed. Increasing it shifts all slats downward at 0% and tapers the offset as the door opens.

--- a/garagedoor-card.js
+++ b/garagedoor-card.js
@@ -12,6 +12,7 @@ class GaragedoorCard extends LitElement {
   #sideGap = 8;   // dark gap to left & right of slats
   #topGap  = 6;   // dark strip above slats at every position
   #bottomGap = 6; // dark strip below slats (was tied to topGap)
+  #closedOffset = 0; // slat offset when closed (tapered as door opens)
   #openLeft = 43; // opening left offset inside 256‑px canvas
   #openTop  = 117; // opening top offset
   #openWidth = 170;
@@ -119,7 +120,8 @@ class GaragedoorCard extends LitElement {
     const containerWidth  = this.#openWidth  - 2 * this.#sideGap;   // 170 - side gaps
     const containerHeight = this.#openHeight - this.#topGap - this.#bottomGap;   // 96 - top & bottom gaps
 
-    const translate = -(pos / 100) * containerHeight; // move slats together
+    const offset = this.#closedOffset * (1 - pos / 100); // taper offset as it opens
+    const translate = offset - (pos / 100) * containerHeight; // move slats together
 
     return html`<div
         class="slats"


### PR DESCRIPTION
## Summary
- add `#closedOffset` to adjust slat position when the door is closed
- offset slats when position is `0` and taper as it opens
- document configuration and new field

## Testing
- `npm test` *(fails: Could not read package.json)*