### PR TITLE
Add double-tap garage door controls with haptics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Double tapping on the door slats now opens Home Assistant's **More Info**
 dialog for the configured garage door entity. Previously this action opened a
 slider overlay for selecting a specific position.
 
+The **Open** and **Close** buttons also require a double tap. When used in the
+iOS companion app, the buttons trigger a light haptic feedback.
+
 ### Adjustable values
 
 Several values near the top of `garagedoor-card.js` can be modified to fine-tune the layout. Among them is the new `#closedOffset` field which controls the extra translation applied to the slats when the door is fully closed. Increasing it shifts all slats downward at 0% and tapers the offset as the door opens.

--- a/garagedoor-card.js
+++ b/garagedoor-card.js
@@ -131,7 +131,19 @@ class GaragedoorCard extends LitElement {
     this._sliderOpen = false;
   }
   _stateObj() { return this.hass?.states?.[this._config.entity]; }
-  _call(svc) { this.hass.callService("cover", svc, { entity_id: this._config.entity }); }
+  _fireHaptic(type) {
+    this.dispatchEvent(
+      new CustomEvent('haptic', {
+        bubbles: true,
+        composed: true,
+        detail: type,
+      })
+    );
+  }
+  _call(svc) {
+    this.hass.callService("cover", svc, { entity_id: this._config.entity });
+    this._fireHaptic('light');
+  }
 
   _lightObj() { return this._config.light_entity ? this.hass?.states?.[this._config.light_entity] : null; }
   _obstructionObj() { return this._config.obstruction_entity ? this.hass?.states?.[this._config.obstruction_entity] : null; }
@@ -194,9 +206,9 @@ class GaragedoorCard extends LitElement {
             : ''}
         </div>
         <div class="actions">
-          <button class="action-btn" @click=${() => this._call("close_cover")}
+          <button class="action-btn" @dblclick=${() => this._call("close_cover")}
             ><ha-icon icon="mdi:arrow-down-bold"></ha-icon><span>Close</span></button>
-          <button class="action-btn" @click=${() => this._call("open_cover")}
+          <button class="action-btn" @dblclick=${() => this._call("open_cover")}
             ><ha-icon icon="mdi:arrow-up-bold"></ha-icon><span>Open</span></button>
         </div>
       </ha-card>`;


### PR DESCRIPTION
## Summary
- require two taps on the open/close buttons
- send a light `haptic` event when the buttons are activated
- document new double-tap behavior in README

## Testing
- `node --version`