### PR TITLE
Add haptic feedback on slat double click

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ If `obstruction_entity` is provided and its state is `on`, a glowing
 obstruction.
 
 Double tapping on the door slats now opens Home Assistant's **More Info**
-dialog for the configured garage door entity. Previously this action opened a
-slider overlay for selecting a specific position.
+dialog for the configured garage door entity and triggers a light haptic
+feedback on supporting devices. Previously this action opened a slider overlay
+for selecting a specific position.
 
 The **Open** and **Close** buttons also require a double tap. When used in the
 iOS companion app, the buttons trigger a light haptic feedback.

--- a/garagedoor-card.js
+++ b/garagedoor-card.js
@@ -169,6 +169,11 @@ class GaragedoorCard extends LitElement {
     );
   }
 
+  _slatsDblClick() {
+    this._showMoreInfo();
+    this._fireHaptic('light');
+  }
+
   _setPosition(ev) {
     const pos = Number(ev.target.value);
     if (!Number.isNaN(pos)) {
@@ -229,7 +234,7 @@ class GaragedoorCard extends LitElement {
 
     return html`<div
         class="slats"
-        @dblclick=${() => this._showMoreInfo()}
+        @dblclick=${() => this._slatsDblClick()}
         style="left:${this.#openLeft + this.#sideGap}px; top:${this.#openTop + this.#topGap}px; width:${containerWidth}px; height:${containerHeight}px;">
       <div class="slat-wrapper" style="transform: translateY(${translate}px);">
         ${Array.from({ length: 5 }).map(() => html`<div class="slat"></div>`)}


### PR DESCRIPTION
## Summary
- trigger a light haptic feedback when the slats are double clicked
- document haptic feedback from slat double clicks

## Testing
- `git status --short`